### PR TITLE
Potential fix for code scanning alert no. 3: Uncontrolled data used in path expression

### DIFF
--- a/examples/smolagents_benchmark/run.py
+++ b/examples/smolagents_benchmark/run.py
@@ -196,8 +196,17 @@ def answer_questions(
     date = date or datetime.date.today().isoformat()
     model_id = model.model_id
 
+    # Validate action_type against an allowlist
+    allowed_action_types = {"code", "search", "interpret"}
+    if action_type not in allowed_action_types:
+        raise ValueError(f"Invalid action_type: {action_type}")
+
     for task in eval_ds:
-        file_name = f"{output_dir}/{model_id.replace('/', '__')}__{action_type}__{task}__{date}.jsonl"
+        raw_file_name = f"{output_dir}/{model_id.replace('/', '__')}__{action_type}__{task}__{date}.jsonl"
+        file_name = os.path.normpath(raw_file_name)
+        if not file_name.startswith(os.path.abspath(output_dir)):
+            raise ValueError(f"Unsafe file path detected: {file_name}")
+
         print(f"Starting processing and writing output to '{file_name}'")
         answered_questions = []
         if os.path.exists(file_name):


### PR DESCRIPTION
Potential fix for [https://github.com/squaredice/smolagents/security/code-scanning/3](https://github.com/squaredice/smolagents/security/code-scanning/3)

To fix the issue, we need to validate the `action_type` value before using it to construct the `file_name` path. A safe approach is to restrict `action_type` to a predefined set of allowed values (e.g., an allowlist). This ensures that only expected values are used in the path construction. Additionally, we can normalize the constructed path using `os.path.normpath` and verify that it remains within the intended `output_dir` directory.

Changes required:
1. Add validation for `action_type` to ensure it matches an allowlist of safe values.
2. Normalize the constructed `file_name` path using `os.path.normpath`.
3. Verify that the normalized path starts with `output_dir` to prevent path traversal.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
