### PR TITLE
Potential fix for code scanning alert no. 6: Jinja2 templating with autoescape=False

### DIFF
--- a/src/smolagents/agents.py
+++ b/src/smolagents/agents.py
@@ -897,7 +897,7 @@ You have been provided with these additional arguments, that you can access usin
             if __name__ == "__main__":
                 GradioUI({{ agent_name }}).launch()
             """).strip()
-        template_env = jinja2.Environment(loader=jinja2.BaseLoader(), undefined=jinja2.StrictUndefined)
+        template_env = jinja2.Environment(loader=jinja2.BaseLoader(), undefined=jinja2.StrictUndefined, autoescape=True)
         template_env.filters["repr"] = repr
         template_env.filters["camelcase"] = lambda value: "".join(word.capitalize() for word in value.split("_"))
         template = template_env.from_string(app_template)


### PR DESCRIPTION
Potential fix for [https://github.com/squaredice/smolagents/security/code-scanning/6](https://github.com/squaredice/smolagents/security/code-scanning/6)

To fix the issue, we need to enable autoescaping for the Jinja2 environment. The best approach is to use `select_autoescape` to automatically enable escaping for file types like HTML and XML, which are prone to XSS attacks. Since the template is dynamically created from a string, we can explicitly set `autoescape=True` to ensure all placeholders are escaped.

Changes to make:
1. Modify the instantiation of `jinja2.Environment` on line 900 to include `autoescape=True`.
2. Ensure that the fix does not alter the functionality of the template rendering process.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
